### PR TITLE
Modded `ssl_certificate_self_signed:` to `no` as it prevents certbot functionality. And serves little purpose as a default everywhere.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ ssl_certificate_path_private: "{{ ssl_certificate_path }}/{{ ssl_certificate_nam
 ssl_certificate_path_combined: "{{ ssl_certificate_path }}/{{ ssl_certificate_name }}.combined"
 ssl_certificate_combined: no
 
-ssl_certificate_self_signed: yes
+ssl_certificate_self_signed: no
 ssl_certificate_self_signed_common_name: "{{ ansible_fqdn }}"
 
 ssl_certificate_self_signed_age: 3650


### PR DESCRIPTION
As this:
`ssl_certificate_self_signed:` "{% if environment_tier not in ['production'] %}yes{% else %}no{% endif %}"`
has been conventional behaviour where ssl-cert has been used this change should not effect any project negatively (especially in prod).